### PR TITLE
Add a random page redirect

### DIFF
--- a/random.html
+++ b/random.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" type="image/jpg" href="assets/favicon.jpg" />
+    <title>random · bucket webring</title>
+
+    <script async>
+      const DATA_FOR_WEBRING = `https://raw.githubusercontent.com/bucketfish/bucket-webring/master/webring.json`;
+      fetch(DATA_FOR_WEBRING)
+        .then((response) => response.json())
+        .then((sites) => {
+          window.location.replace(sites[Math.floor(Math.random()*sites.length)]["url"]);
+        });
+    </script>
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
I am a part of 2 webrings (soon 3, probably last) and seemingly Bucketfish webring is the only one that has no 'random site' redirect. Therefore, I have added a 'random site' functionality.

It uses the Math.random() as well as .floor() functions to choose a random element from the webring.json array, and then redirects the users to that website.

To add it to your site, you can just do the following:

    <a href="https://webring.bucketfish.me/random.html">Redirect to random website on the Bucketfish webring :)</a>

I have tested this locally and it works flawlessly.