### PR TITLE
uhh thinliquids commit broke it 

### DIFF
--- a/webring.json
+++ b/webring.json
@@ -200,5 +200,5 @@
   { "name": "reiyua", "url": "https://reiyua.neocities.org" },
   { "name": "robbi", "url": "https://journal.robbi.my" },
   { "name": "moosyu", "url": "https://moosyu.github.io/" },
-  { "name": "ThinLiquid": "url": "https://thinliquid.dev" }
+  { "name": "ThinLiquid", "url": "https://thinliquid.dev" }
 ]


### PR DESCRIPTION
it was   { "name": "ThinLiquid": "url": "https://thinliquid.dev" }
instead of   { "name": "ThinLiquid", "url": "https://thinliquid.dev" }

