### PR TITLE
Add shuffle functionality to display sites in random order

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,39 +1,42 @@
 const DATA_FOR_WEBRING = `https://raw.githubusercontent.com/bucketfishy/bucket-webring/master/webring.json`;
 
-
 const list = document.getElementById("peoplelist");
 const count = document.getElementById("peoplecount");
 
 function convertHTML(str) {
-  var regexTable =  {
+  const regexTable = {
     '&': '&amp;',
     '<': '&lt;',
     '>': '&gt;',
     '"': '&quot;',
-    '\'': '&apos;'
-    };
+    "'": '&apos;'
+  };
 
   let result = str;
+  const regexKeys = Object.keys(regexTable);
 
-  var regexKeys = Object.keys(regexTable);
-
-  for (var i=0; i<regexKeys.length; i++) {
-
-    let regex = new RegExp(regexKeys[i], 'g');
+  for (let i = 0; i < regexKeys.length; i++) {
+    const regex = new RegExp(regexKeys[i], 'g');
     result = result.replace(regex, regexTable[regexKeys[i]]);
   }
 
   return result;
 }
 
+function shuffle(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array;
+}
+
 fetch(DATA_FOR_WEBRING)
   .then((response) => response.json())
   .then((sites) => {
-    count.innerHTML = sites.length;
-
-    for (var i = 0; i < sites.length; i++){
-      list.innerHTML += "<div><p><a href=" + sites[i].url + ">" + convertHTML(sites[i].name) + "</a></p></div>";
-    }
-
-
-  });
+    const shuffledSites = shuffle(sites);
+    count.innerHTML = shuffledSites.length;
+    shuffledSites.forEach(site => {
+      list.innerHTML += `<div><p><a href="${site.url}">${convertHTML(site.name)}</a></p></div>`;
+    });
+  });  


### PR DESCRIPTION
This PR introduces a feature to shuffle the data fetched from the webring JSON file, ensuring that the list of sites is displayed in a random order each time the page is loaded.

#### Changes Made:
1. **Added `shuffle` Function:**
   - Implements the Fisher-Yates algorithm to randomize the order of the array.
2. **Integrated `shuffle` into Fetch Workflow:**
   - The `sites` array is now shuffled before rendering the content on the page.
3. **Updated DOM Rendering:**
   - Modified the loop to use the shuffled array for rendering site links dynamically.

#### Benefits:
- Enhances user experience by varying the order of displayed sites on each page load.
- Encourages visibility for all sites in the webring.

#### Code Example:
```javascript
function shuffle(array) {
  for (let i = array.length - 1; i > 0; i--) {
    const j = Math.floor(Math.random() * (i + 1));
    [array[i], array[j]] = [array[j], array[i]];
  }
  return array;
}

fetch(DATA_FOR_WEBRING)
  .then((response) => response.json())
  .then((sites) => {
    const shuffledSites = shuffle(sites);
    count.innerHTML = shuffledSites.length;

    shuffledSites.forEach(site => {
      list.innerHTML += `<div><p><a href="${site.url}">${convertHTML(site.name)}</a></p></div>`;
    });
  });
```

#### How to Test:
1. Load the page and observe the order of the sites.
2. Reload the page multiple times to verify that the order changes.

---

I want to add that I really enjoyed working on this project, and I hope these changes align with the goals of the webring. It’s a fantastic initiative, and I’d love to see this feature implemented to further improve user engagement. 🚀

Let me know if there's anything else I can do to refine these changes. 😊

---