### PR TITLE
Fix Gaiety.me link

### DIFF
--- a/webring.json
+++ b/webring.json
@@ -253,7 +253,7 @@
   { "name": "sprite", "url": "https://riflesniper.art/" },
   { "name": "MilesWK", "url": "https://www.mileswk.com/" },
   { "name": "DragonnFire", "url": "http://johnbot.org" },
-  { "name": "Gaiety.me", "url": "https//gaiety.me/" },
+  { "name": "Gaiety.me", "url": "https://gaiety.me/" },
   { "name": "onthe12thfloor", "url": "https://onthe12thfloor.com/" },
   { "name": "myon", "url": "https://myon.xyz/" },
   { "name": "RoBaertschi", "url": "https://robaertschi.xyz/" },


### PR DESCRIPTION
While going through the Webring, I noticed that the url for Gaiety.me  is invalid, it is missing the colon after the https. It seems, that link was already invalid when added.


This issue was introduced [here](https://github.com/bucketfish/bucket-webring/commit/4e0cb42c0e36668a717dbc1e3159a4f82555669f).