### PR TITLE
Adding an option to change the background colour of the embed.

### DIFF
--- a/embed.html
+++ b/embed.html
@@ -145,7 +145,8 @@
     if (colour){
       var r = document.querySelector(':root');
       r.style.setProperty('--background', colour);
-    
+    }
+      
     if (lightmode){
       console.log("AAAA");
 

--- a/embed.html
+++ b/embed.html
@@ -139,8 +139,13 @@
     const queryString = window.location.search;
     const urlParams = new URLSearchParams(queryString);
     const lightmode = urlParams.get("lightmode");
+    const colour = urlParams.get("colour");
     const name = urlParams.get('name');
 
+    if (colour){
+      var r = document.querySelector(':root');
+      r.style.setProperty('--background', colour);
+    
     if (lightmode){
       console.log("AAAA");
 


### PR DESCRIPTION
Example - `https://webring.bucketfish.me/embed.html?colour=%23ff0000` will set the background colour to `#ff0000` (The %23 is a #).

Working link for an example to test this: [https://spag.site/bucket-webring/embed.html?colour=%23ff0000](https://spag.site/bucket-webring/embed.html?colour=%23ff0000), you can change the last 6 characters (currently ff0000) to any valid hex colour and it will change the background colour of the page.

To use this as an embed you would use `<iframe id="bucket-webring" style="width: 100%; height: 2rem; border: none;" src="https://webring.bucketfish.me/embed.html?name=YOURNAME&colour=%23ff0000"></iframe>` on your page.
